### PR TITLE
Updated travis for new clang release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,21 @@ language: cpp
 env:
   - C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9
   - C_COMPILER=gcc-5 CXX_COMPILER=g++-5
-  - C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
   - C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6
   - C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7
+  - C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
+  - C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main" | sudo tee -a /etc/apt/sources.list
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | sudo tee -a /etc/apt/sources.list
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main" | sudo tee -a /etc/apt/sources.list
+  - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main" | sudo tee -a /etc/apt/sources.list
+  - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -q
   - sudo apt-get install gcc-4.9 g++-4.9 gcc-5 g++-5 -y
-  - sudo apt-get install clang-3.6 clang-3.7 clang-3.8 -y
+  - sudo apt-get install clang-3.6 clang-3.7 clang-3.8 clang-3.9 -y
   - sudo apt-get install libboost-all-dev libeigen3-dev libopencv-dev opencv-data -y
 
 before_script:


### PR DESCRIPTION
This fixes failing to build because clang-3.8 can no longer be found - it moved to the llvm *-3.8 repo.