### PR TITLE
Removed clang-3.9 and llvm trusty main repo from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6
   - C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7
   - C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
-  - C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -17,10 +16,9 @@ before_install:
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | sudo tee -a /etc/apt/sources.list
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main" | sudo tee -a /etc/apt/sources.list
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main" | sudo tee -a /etc/apt/sources.list
-  - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -q
   - sudo apt-get install gcc-4.9 g++-4.9 gcc-5 g++-5 -y
-  - sudo apt-get install clang-3.6 clang-3.7 clang-3.8 clang-3.9 -y
+  - sudo apt-get install clang-3.6 clang-3.7 clang-3.8 -y
   - sudo apt-get install libboost-all-dev libeigen3-dev libopencv-dev opencv-data -y
 
 before_script:


### PR DESCRIPTION
We would have to add the trusty-3.9 repo, and the repo without version number probably now contains clang-4.0.
However, updating this with every clang release is a bit tedious, so I'll remove it for now.